### PR TITLE
Harden x402 payment gate and close WS publish bypass

### DIFF
--- a/src/relay.mjs
+++ b/src/relay.mjs
@@ -64,20 +64,13 @@ export class Relay {
 
     switch (type) {
       case 'EVENT': {
-        // Over WebSocket, we accept events directly (no x402 gate).
-        // The x402 gate is on the HTTP endpoint.
-        // For WS, we can either reject or accept — design says HTTP for publishing,
-        // but let's accept WS events too for standard Nostr client compat.
-        const event = msg[1];
-        if (!event || !event.id || !event.pubkey || event.kind == null) {
-          ws.send(JSON.stringify(['OK', event?.id || '', false, 'invalid: missing fields']));
-          return;
-        }
-        const added = this.store.add(event);
-        ws.send(JSON.stringify(['OK', event.id, true, '']));
-        if (added) {
-          this._broadcast(event);
-        }
+        const eventId = msg[1]?.id || '';
+        ws.send(JSON.stringify([
+          'OK',
+          eventId,
+          false,
+          'payment-required: publish via HTTP POST /api/events',
+        ]));
         break;
       }
 


### PR DESCRIPTION
## Summary
This PR hardens x402 payment enforcement and closes payment-bypass paths.

### Changes
- reject WebSocket `EVENT` writes so all publishing is enforced through HTTP `POST /api/events` payment flow
- enforce minimum amount checks for `token_transfer` payments
- reject unsupported successful tx types instead of accepting by default
- normalize tx IDs before replay checks to block casing/whitespace replay bypasses
- add tests covering payment underpay, unknown tx type, and WS event gate behavior

## Why
Issue #1 requests a security-focused review of x402 verification and relay correctness. These fixes address concrete bypass paths where unpaid or underpaid writes could be accepted.

## Validation
- `npm test`
